### PR TITLE
Correct flip orchestration

### DIFF
--- a/05-layout/index.final.html
+++ b/05-layout/index.final.html
@@ -62,9 +62,8 @@
     function flip(fn, firstEls, lastEls = firstEls) {
       const firstRects = firstEls.map((el) => el.getBoundingClientRect());
 
-      fn();
-
       requestAnimationFrame(() => {
+        fn();
         const lastRects = lastEls.map((el) => el.getBoundingClientRect());
 
         lastRects.forEach((lastRect, i) => {


### PR DESCRIPTION
The transform function should be called inside the `requestAnimationFrame` to avoid (inappreciable) flicker between states.